### PR TITLE
Adding alias to driver

### DIFF
--- a/driver/prepare.go
+++ b/driver/prepare.go
@@ -44,8 +44,15 @@ func prepareContainer(cfg *drivers.TaskConfig, taskCfg TaskConfig) (syexec, erro
 		taskCfg.Command = "\"" + taskCfg.Command + "\""
 		argv = append(argv, "-c", taskCfg.Command)
 	}
-	if taskCfg.NetworkMode != "" {
+
+	if taskCfg.NetworkMode != "" && taskCfg.NetworkMode != "alias" && taskCfg.NetworkMode != "host" {
 		argv = append(argv, "-N", taskCfg.NetworkMode)
+	} else if taskCfg.NetworkMode == "alias" {
+		if taskCfg.IP == "" {
+			err := errors.New("ip can not be empty if network_mode is set to alias")
+			return se, err
+		}
+		argv = append(argv, "-N", "alias", "-i", taskCfg.IP)
 	} else if len(taskCfg.PortMap) > 0 {
 		argv = append(argv, "-N", "public-bridge", "-i", "auto")
 	}


### PR DESCRIPTION
This works on the consul level but the address in nomad is still wrong.
```
Task "task1" is "running"
Task Resources
CPU        Memory          Disk     Addresses
0/200 MHz  16 MiB/128 MiB  300 MiB  bla: 172.20.132.250:80

```
Consul shows it as:
https://upload.thaller.ws/files/5b070df9f0864c19b87031a47038e66889adf794/2020-03-13_18-30-25_3480.png

The ip specified inside the job is `172.20.132.251` as shown by consul.
