### PR TITLE
Fix Deprecation of network-stanza in resources

### DIFF
--- a/driver/prepare.go
+++ b/driver/prepare.go
@@ -52,8 +52,8 @@ func prepareContainer(cfg *drivers.TaskConfig, taskCfg TaskConfig) (syexec, erro
 
 	if taskCfg.NetworkMode != "host" {
 		for name, port := range taskCfg.PortMap {
-			_, portInt := cfg.Resources.NomadResources.Networks.Port(name)
-			sPort := strconv.Itoa(portInt)
+			envname := "NOMAD_HOST_PORT_" + name
+			sPort := cfg.Env[envname]
 			completePort := port + ":" + sPort
 			argv = append(argv, "-e", completePort)
 		}


### PR DESCRIPTION
This fixes #24 for me and allows the network-block to reside in the group instead of the resources-block. It is a bit hacky and needs some work, but it works for my simple use-case.